### PR TITLE
SNPE compatible; fix timm version

### DIFF
--- a/effdet/bench.py
+++ b/effdet/bench.py
@@ -129,8 +129,10 @@ class DetBenchTrain(nn.Module):
             self.anchor_labeler = AnchorLabeler(self.anchors, self.num_classes, match_threshold=0.5)
         self.loss_fn = DetectionLoss(model.config)
 
-    def forward(self, x, target: Dict[str, torch.Tensor]):
+    def forward(self, x, target: Dict[str, torch.Tensor] = None):
         class_out, box_out = self.model(x)
+        if target is None:
+            return class_out, box_out
         if self.anchor_labeler is None:
             # target should contain pre-computed anchor labels if labeler not present in bench
             assert 'label_num_positives' in target

--- a/effdet/efficientdet.py
+++ b/effdet/efficientdet.py
@@ -214,16 +214,17 @@ class FpnCombine(nn.Module):
         if self.weight_method == 'attn':
             normalized_weights = torch.softmax(self.edge_weights.to(dtype=dtype), dim=0)
             out = torch.stack(nodes, dim=-1) * normalized_weights
+            raise NotImplementedError
         elif self.weight_method == 'fastattn':
             edge_weights = nn.functional.relu(self.edge_weights.to(dtype=dtype))
             weights_sum = torch.sum(edge_weights)
-            out = torch.stack(
-                [(nodes[i] * edge_weights[i]) / (weights_sum + 0.0001) for i in range(len(nodes))], dim=-1)
+            out = sum(
+                [(nodes[i] * edge_weights[i]) / (weights_sum + 0.0001) for i in range(len(nodes))])
         elif self.weight_method == 'sum':
-            out = torch.stack(nodes, dim=-1)
+            out = sum(nodes)
         else:
             raise ValueError('unknown weight_method {}'.format(self.weight_method))
-        out = torch.sum(out, dim=-1)
+        # out = torch.sum(out, dim=-1)
         return out
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.4.0
-timm>=0.4.12
+timm<=0.5.7
 torchvision
 pyyaml
 numpy


### PR DESCRIPTION
- [x] Update `efficientdet.py` to avoid generating 5-d tensor
- [x] Make postprocess optional in `bench.py` to facilitate onnx exporting and DLC compilation
- [x] Fix timm version to 5.7, as the latest timm 6.x has accuracy degradation and cannot reproduce baseline